### PR TITLE
fix: use elapsed_time for non-run activity descriptions

### DIFF
--- a/signals/probes/strava_to_gcal/run.py
+++ b/signals/probes/strava_to_gcal/run.py
@@ -105,7 +105,7 @@ def create_gcal_event(service, calendar_map: dict[str, str], activity: dict) -> 
     if sport_type == "Run" and activity["distance"] > 0:
         description = format_run_description(activity["distance"], activity["moving_time"])
     else:
-        description = format_duration_description(activity["moving_time"])
+        description = format_duration_description(activity["elapsed_time"])
 
     # start_date_local carries the Z suffix but represents local time — treat as naive
     start_dt = datetime.fromisoformat(activity["start_date_local"].replace("Z", ""))


### PR DESCRIPTION
## Summary
- For climbing and weightlifting, `moving_time` tracks GPS movement which is near-zero (e.g. 26s for a 68-min climbing session)
- The calendar event duration already uses `elapsed_time` correctly — description now matches

## Test plan
- [ ] Verify next climbing/weightlifting session shows the correct duration in the GCal event description

🤖 Generated with [Claude Code](https://claude.com/claude-code)